### PR TITLE
グラフ表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,11 @@
         "react": "19.0.0",
         "react-native": "^0.79.5",
         "react-native-calendars": "^1.1313.0",
+        "react-native-chart-kit": "^6.12.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-svg": "^15.11.2"
+        "react-native-svg": "^15.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -10007,6 +10008,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/paths-js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/paths-js/-/paths-js-0.4.11.tgz",
+      "integrity": "sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.11.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10056,6 +10066,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -10477,6 +10493,22 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-chart-kit": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.0.tgz",
+      "integrity": "sha512-nZLGyCFzZ7zmX0KjYeeSV1HKuPhl1wOMlTAqa0JhlyW62qV/1ZPXHgT8o9s8mkFaGxdqbspOeuaa6I9jUQDgnA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.13",
+        "paths-js": "^0.4.10",
+        "point-in-polygon": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": "> 16.7.0",
+        "react-native": ">= 0.50.0",
+        "react-native-svg": "> 6.4.1"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -10536,9 +10568,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.11.2",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.11.2.tgz",
-      "integrity": "sha512-+YfF72IbWQUKzCIydlijV1fLuBsQNGMT6Da2kFlo1sh+LE3BIm/2Q7AR1zAAR6L0BFLi1WaQPLfFUC9bNZpOmw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.0.tgz",
+      "integrity": "sha512-iE25PxIJ6V0C6krReLquVw6R0QTsRTmEQc4K2Co3P6zsimU/jltcDBKYDy1h/5j9S/fqmMeXnpM+9LEWKJKI6A==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "react": "19.0.0",
     "react-native": "^0.79.5",
     "react-native-calendars": "^1.1313.0",
+    "react-native-chart-kit": "^6.12.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-svg": "^15.11.2"
+    "react-native-svg": "^15.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -3,6 +3,7 @@ import { Tabs, useRouter } from 'expo-router'
 import UserIcon from '../components/Icon/UserIcon'
 import HomeIcon from '../components/Icon/HomeIcon'
 import DiaryCreationIcon from '../components/Icon/DiaryCreationIcon'
+import AnalysisIcon from '../components/Icon/AnalysisIcon'
 
 export default function TabLayout() {
 
@@ -58,6 +59,16 @@ export default function TabLayout() {
               }
             });
           },
+        }}
+      />
+      <Tabs.Screen
+        name="analysis"
+        options={{
+          title: "分析レポート",
+          headerShown: false,
+          tabBarIcon: ({ color, size }) => (
+            <AnalysisIcon width={size} height={size} color={color} />
+          ),
         }}
       />
       <Tabs.Screen

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -130,7 +130,7 @@ export default function analysis() {
       </View>
       <View style={styles.card}>
         {/* グラフエリア */}
-        {hasDataToRender && (
+        {hasDataToRender ? (
           <View style={styles.chartContainer}>
             {/* グラフ本体 */}
             <LineChart
@@ -190,6 +190,10 @@ export default function analysis() {
                 />
               ))}
             </View>
+          </View>
+        ): (
+          <View style={styles.noDataContainer}>
+            <Text style={styles.noDataText}>データがありません</Text>
           </View>
         )}
       </View>
@@ -252,4 +256,14 @@ const styles = StyleSheet.create({
     height: 220, // グラフの高さと同じ
     zIndex: 1, // グラフの上に表示
   },
+  noDataContainer: {
+    height: 220,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  noDataText: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#000000',
+  }
 });

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -29,8 +29,8 @@ const MoodChartWithIcons = () => {
         // 画像のグラフをざっくり再現
         // データの値はmoodImagesのインデックスに対応させます (0が一番上、4が一番下)
         data: [0, 1, 4, 2, 1, 4, 0],
-        color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // 線の色 (黒)
-        strokeWidth: 2,
+        color: (opacity = 1) => `rgba(255, 165, 0, ${opacity})`, // 線の色（オレンジ）
+        strokeWidth: 3, // 線の太さを増加
       },
     ],
   };
@@ -39,14 +39,29 @@ const MoodChartWithIcons = () => {
   const chartConfig = {
     backgroundGradientFrom: '#FFFFFF',
     backgroundGradientTo: '#FFFFFF',
-    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`, // グリッド線やラベルの色
-    labelColor: (opacity = 1) => `rgba(100, 100, 100, ${opacity})`, // X軸ラベルの色
+    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`, // グリッド線の色（黒）
+    labelColor: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // X軸ラベルの色
     strokeWidth: 2,
     // データポイントの丸を非表示にする
     propsForDots: {
       r: '3',
       strokeWidth: '0',
-      fill: '#000000',
+      fill: '#FFA500',
+    },
+    // グリッド線の設定
+    propsForBackgroundLines: {
+      strokeDasharray: '', // 実線
+      strokeWidth: 1, // 線の太さ
+      stroke: '#000000', // 線の色
+    },
+    // Y軸の線を表示
+    propsForVerticalLabels: {
+      fontSize: 0, // Y軸ラベルは非表示
+    },
+    // X軸の線を表示
+    propsForHorizontalLabels: {
+      fontSize: 12, // X軸ラベルのフォントサイズ
+
     },
   };
 
@@ -63,12 +78,15 @@ const MoodChartWithIcons = () => {
           withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
           withVerticalLabels={true} // X軸のラベルは表示
           withHorizontalLines={true} // 水平線を表示
+          withVerticalLines={true} // 垂直線を表示
           withDots={true} // データポイントを非表示
           // bezierを付けないことで、カクカクした線になる
           // データを0から開始しないようにする（データの最小値が基点になる）
           fromZero={false}
           // 5段階なので4つの区切り
           segments={4}
+          // X軸の一番下の線を表示するための設定
+          withInnerLines={false} // 内側の線を表示
         />
 
         {/* 絶対配置でY軸アイコンを配置 */}

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, View, Dimensions } from 'react-native';
 import { Image } from 'expo-image'
 import { LineChart } from 'react-native-chart-kit';
+import Header from '../analysis/components/Header';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -66,46 +67,49 @@ const MoodChartWithIcons = () => {
   };
 
   return (
-    <View style={styles.card}>
-      {/* グラフエリア */}
-      <View style={styles.chartContainer}>
-        {/* グラフ本体 */}
-        <LineChart
-          data={data}
-          width={screenWidth - 80} // カードのpaddingやY軸の幅を引く
-          height={220}
-          chartConfig={chartConfig}
-          withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
-          withVerticalLabels={true} // X軸のラベルは表示
-          withHorizontalLines={true} // 水平線を表示
-          withVerticalLines={true} // 垂直線を表示
-          withDots={true} // データポイントを非表示
-          // bezierを付けないことで、カクカクした線になる
-          // データを0から開始しないようにする（データの最小値が基点になる）
-          fromZero={false}
-          // 5段階なので4つの区切り
-          segments={4}
-          // X軸の一番下の線を表示するための設定
-          withInnerLines={false} // 内側の線を表示
-        />
+    <View style={styles.container}>
+      <Header />
+      <View style={styles.card}>
+        {/* グラフエリア */}
+        <View style={styles.chartContainer}>
+          {/* グラフ本体 */}
+          <LineChart
+            data={data}
+            width={screenWidth - 80} // カードのpaddingやY軸の幅を引く
+            height={220}
+            chartConfig={chartConfig}
+            withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
+            withVerticalLabels={true} // X軸のラベルは表示
+            withHorizontalLines={true} // 水平線を表示
+            withVerticalLines={true} // 垂直線を表示
+            withDots={true} // データポイントを非表示
+            // bezierを付けないことで、カクカクした線になる
+            // データを0から開始しないようにする（データの最小値が基点になる）
+            fromZero={false}
+            // 5段階なので4つの区切り
+            segments={4}
+            // X軸の一番下の線を表示するための設定
+            withInnerLines={false} // 内側の線を表示
+          />
 
-        {/* 絶対配置でY軸アイコンを配置 */}
-        <View style={styles.absoluteYAxis}>
-          {moodImages.map((imgSrc, index) => (
-            <Image
-              key={index}
-              source={imgSrc}
-              style={[
-                styles.moodIcon,
-                {
-                  top: (index * 41), // 各アイコンの位置を計算（36px間隔）
-                  left: 0, // 左端に配置
-                }
-              ]}
-              contentFit="cover"
-              cachePolicy="memory-disk"
-            />
-          ))}
+          {/* 絶対配置でY軸アイコンを配置 */}
+          <View style={styles.absoluteYAxis}>
+            {moodImages.map((imgSrc, index) => (
+              <Image
+                key={index}
+                source={imgSrc}
+                style={[
+                  styles.moodIcon,
+                  {
+                    top: (index * 41), // 各アイコンの位置を計算（36px間隔）
+                    left: 0, // 左端に配置
+                  }
+                ]}
+                contentFit="cover"
+                cachePolicy="memory-disk"
+              />
+            ))}
+          </View>
         </View>
       </View>
     </View>
@@ -114,6 +118,9 @@ const MoodChartWithIcons = () => {
 
 // スタイル定義
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   card: {
     margin: 20,
     backgroundColor: 'white',

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -224,7 +224,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     borderRadius: 16,
     paddingVertical: 20,
-    paddingHorizontal: 10,
   },
   chartContainer: {
     flexDirection: 'row',
@@ -248,7 +247,7 @@ const styles = StyleSheet.create({
   absoluteYAxis: {
     position: 'absolute',
     top: 0, // グラフの上部余白を考慮
-    left: 10, // 左端からの距離
+    left: 20, // 左端からの距離
     width: 32, // アイコンの幅
     height: 220, // グラフの高さと同じ
     zIndex: 1, // グラフの上に表示

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -96,6 +96,7 @@ export default function analysis() {
   return (
     <View style={styles.container}>
       <Header
+        title="分析レポート"
         userInfo={userInfo}
         selectedUserInfo={selectedUserInfo}
         friendsData={friendsData}

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { StyleSheet, View, Dimensions } from 'react-native';
+import { Image } from 'expo-image'
+import { LineChart } from 'react-native-chart-kit';
+
+const screenWidth = Dimensions.get('window').width;
+
+// 用意した画像をrequireで読み込み、配列にまとめる
+// 上から順（良い気分 -> 悪い気分）に並べるのがポイント
+const moodImages = [
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/excellent_icon.png'), // データ値: 0
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/good_icon.png'), // データ値: 1
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/normal_icon.png'), // データ値: 2
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/bad_icon.png'), // データ値: 3
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/terrible_icon.png'), // データ値: 4
+];
+
+const MoodChartWithIcons = () => {
+  // グラフ用のデータ
+  const data = {
+    labels: ['7/1', '7/6', '7/11', '7/16', '7/21', '7/26', '7/31'],
+    datasets: [
+      {
+        // 画像のグラフをざっくり再現
+        // データの値はmoodImagesのインデックスに対応させます (0が一番上、4が一番下)
+        data: [
+          0, // 7/1: 最高
+          1,
+          4, // 7/3あたり: 最悪
+          2,
+          1,
+          4, // 7/8あたり: 最悪
+          0, // 7/11: 最高
+        ],
+        color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // 線の色 (黒)
+        strokeWidth: 2,
+      },
+    ],
+  };
+
+  // グラフのスタイル設定
+  const chartConfig = {
+    backgroundGradientFrom: '#ffffff',
+    backgroundGradientTo: '#ffffff',
+    color: (opacity = 1) => `rgba(200, 200, 200, ${opacity})`, // グリッド線やラベルの色
+    labelColor: (opacity = 1) => `rgba(100, 100, 100, ${opacity})`, // X軸ラベルの色
+    strokeWidth: 2,
+    // データポイントの丸を非表示にする
+    propsForDots: {
+      r: '3',
+      strokeWidth: '0',
+    },
+    // Y軸の数値を非表示
+    withVerticalLabels: false,
+    // 水平のグリッド線を非表示
+    withHorizontalLines: false,
+    // 垂直のグリッド線は表示
+    withVerticalLines: true,
+  };
+
+  return (
+    <View style={styles.card}>
+      {/* グラフエリア */}
+      <View style={styles.chartContainer}>
+        {/* カスタムY軸 (アイコン) */}
+        <View style={styles.customYAxis}>
+          {moodImages.map((imgSrc, index) => (
+            <Image
+              key={index}
+              source={imgSrc}
+              style={styles.moodIcon}
+              contentFit="cover"
+              cachePolicy="memory-disk"
+            />
+          ))}
+        </View>
+
+        {/* グラフ本体 */}
+        <LineChart
+          data={data}
+          width={screenWidth - 80} // カードのpaddingやY軸の幅を引く
+          height={220}
+          chartConfig={chartConfig}
+          withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
+          withHorizontalLines={true} // 水平線を表示
+          withDots={true} // データポイントを非表示
+          // bezierを付けないことで、カクカクした線になる
+          style={styles.chart}
+          // データを0から開始しないようにする（データの最小値が基点になる）
+          fromZero={false}
+          // Y軸のラベルを描画しないためのオフセット
+          yLabelsOffset={20}
+          // 5段階なので4つの区切り
+          segments={4}
+        />
+      </View>
+    </View>
+  );
+};
+
+// スタイル定義
+const styles = StyleSheet.create({
+  card: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 16,
+    paddingVertical: 20,
+    paddingHorizontal: 10,
+    // 影をつけたい場合
+    // shadowColor: '#000',
+    // shadowOffset: { width: 0, height: 2 },
+    // shadowOpacity: 0.1,
+    // shadowRadius: 4,
+    // elevation: 3,
+  },
+  chartContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start', // アイコンとグラフの上端を合わせる
+  },
+  customYAxis: {
+    height: 220, // グラフの高さと合わせる
+    justifyContent: 'space-between', // アイコンを均等に配置
+    paddingRight: 10,
+    paddingVertical: 5, // 上下の余白を微調整
+  },
+  moodIcon: {
+    width: 32,
+    height: 32,
+    resizeMode: 'contain',
+  },
+  chart: {
+    // グラフの左側に余白が自動で入る場合があるので、マイナスマージンで調整
+    marginLeft: -15,
+  },
+});
+
+export default MoodChartWithIcons;

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { StyleSheet, View, Text, Dimensions, TouchableOpacity } from 'react-native';
-import { Image } from 'expo-image'
-import { LineChart } from 'react-native-chart-kit';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
 import Header from '../diary/list/components/Header';
-import feelingImageList from '../constants/feelingImageList';
 import { auth } from '../../config';
 import dayjs from 'dayjs';
 import YearMonthSelectModal from '../diary/list/components/YearMonthSelectModal';
@@ -13,8 +10,7 @@ import { UserInfoType } from '../../../type/userInfo';
 import fetchUserInfo from '../actions/fetchUserInfo';
 import fetchFriends from '../actions/backend/fetchFriends';
 import { FriendInfoType } from '../../../type/friend';
-
-const screenWidth = Dimensions.get('window').width;
+import FeelingScoreGraph from '../analysis/components/FeelingScoreGraph';
 
 export default function analysis() {
   const userId = auth.currentUser?.uid
@@ -37,15 +33,13 @@ export default function analysis() {
     }
   }, [userId, selectedUserId]);
 
+  // 日記を表示しているユーザー情報を取得
   useEffect(() => {
     if (userId === null || !selectedUserId) return;
-
-    // 日記を表示しているユーザー情報を取得
     const unsubscribe = fetchUserInfo({
       userId: selectedUserId,
       setUserInfo: setSelectedUserInfo,
     });
-
     fetchFriends(setFriendsData, userId);
     return unsubscribe;
   }, [selectedUserId])
@@ -53,7 +47,6 @@ export default function analysis() {
   // ログインユーザー情報を取得
   useEffect(() => {
     if (userId === null) return;
-    // ログイン情報取得
     const unsubscribe = fetchUserInfo({
       userId,
       setUserInfo,
@@ -94,67 +87,11 @@ export default function analysis() {
     return chartDataValues.some(value => value !== null);
   }, [chartDataValues]);
 
+  // モーダルを開くときに、現在の表示年月をピッカーの初期値に設定する
   const handleYearMonthPress = () => {
-    // モーダルを開くときに、現在の表示年月をピッカーの初期値に設定する
     setSelectedYearMonth(displayDate.format('YYYY-M'));
     setModalVisible(true);
   }
-
-
-  // グラフ用のデータ
-  const data = useMemo(() => {
-    const yAxisMax = 10;
-    const yAxisMin = -10;
-    return {
-      // ダミーデータに合わせて、labelsの最初と最後に空文字を追加
-      labels: [ ...allDaysInMonth, '', ''],
-      datasets: [
-        {
-          // データの最初と最後にY軸の最大/最小値をダミーとして追加
-          data: chartDataValues,
-          color: (opacity = 1) => `rgba(255, 165, 0, ${opacity})`,
-          strokeWidth: 3,
-        },
-        {
-          // Dataset 2: Y軸のスケールを固定するための非表示データ
-          data: [yAxisMax, yAxisMin],
-          // 線とドットを完全に見えなくする
-          withDots: false,
-          color: () => `rgba(0, 0, 0, 0)`,
-          strokeWidth: 0,
-        },
-      ],
-    };
-  }, [chartDataValues, allDaysInMonth]);
-
-  // グラフのスタイル設定
-  const chartConfig = {
-    backgroundGradientFrom: '#FFFFFF',
-    backgroundGradientTo: '#FFFFFF',
-    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`, // グリッド線の色（黒）
-    labelColor: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // X軸ラベルの色
-    strokeWidth: 2,
-    propsForDots: {
-      r: '4',
-      strokeWidth: '0',
-      fill: '#FFA500',
-    },
-    // グリッド線の設定
-    propsForBackgroundLines: {
-      strokeDasharray: '', // 実線
-      strokeWidth: 1, // 線の太さ
-      stroke: '#000000', // 線の色
-    },
-    // Y軸の線を表示
-    propsForVerticalLabels: {
-      fontSize: 0, // Y軸ラベルは非表示
-    },
-    // X軸の線を表示
-    propsForHorizontalLabels: {
-      fontSize: 12, // X軸ラベルのフォントサイズ
-
-    },
-  };
 
   return (
     <View style={styles.container}>
@@ -171,68 +108,9 @@ export default function analysis() {
         </TouchableOpacity>
       </View>
       <View style={styles.card}>
-        {/* グラフエリア */}
+        {/* グラフ表示 */}
         {hasDataToRender ? (
-          <View style={styles.chartContainer}>
-            {/* グラフ本体 */}
-            <LineChart
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              data={data as any}
-              width={screenWidth - 80} // カードのpaddingやY軸の幅を引く
-              height={220}
-              chartConfig={chartConfig}
-              withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
-              withVerticalLabels={true} // X軸のラベルは表示
-              withHorizontalLines={true} // 水平線を表示
-              withVerticalLines={true} // 垂直線を表示
-              withDots={true} // データポイントを非表示
-              // bezierを付けないことで、カクカクした線になる
-              // データを0から開始しないようにする（データの最小値が基点になる）
-              fromZero={false}
-              // 5段階なので4つの区切り
-              segments={4}
-              // X軸の一番下の線を表示するための設定
-              withInnerLines={false} // 内側の線を表示
-              hidePointsAtIndex={[chartDataValues.length + 1]}
-              getDotProps={(value) => {
-                if (value === null) {
-                  return { r: '0' }; // 半径0で見えなくする
-                }
-                return chartConfig.propsForDots;
-              }}
-              formatXLabel={(label) => {
-                const day = parseInt(label.split('/')[1], 10);
-                // 1日、または5の倍数の日だけラベルを表示
-                // ダミーデータ用の空ラベルは表示しない
-                if (label === '') {
-                  return '';
-                }
-                if (day === 1 || day % 5 === 0) {
-                  return label;
-                }
-                return ''; // それ以外は空文字にして非表示
-              }}
-            />
-
-            {/* 絶対配置でY軸アイコンを配置 */}
-            <View style={styles.absoluteYAxis}>
-              {feelingImageList.map((imgSrc, index) => (
-                <Image
-                  key={index}
-                  source={imgSrc}
-                  style={[
-                    styles.moodIcon,
-                    {
-                      top: (index * 41), // 各アイコンの位置を計算（36px間隔）
-                      left: 0, // 左端に配置
-                    }
-                  ]}
-                  contentFit="cover"
-                  cachePolicy="memory-disk"
-                />
-              ))}
-            </View>
-          </View>
+          <FeelingScoreGraph allDaysInMonth={allDaysInMonth} chartDataValues={chartDataValues} />
         ): (
           <View style={styles.noDataContainer}>
             <Text style={styles.noDataText}>データがありません</Text>
@@ -251,7 +129,6 @@ export default function analysis() {
   );
 };
 
-// スタイル定義
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -276,27 +153,6 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start', // アイコンとグラフの上端を合わせる
     justifyContent: 'flex-start', // 左寄せ
     position: 'relative', // 絶対配置の基準点
-  },
-  customYAxis: {
-    height: 220, // グラフの高さと合わせる
-    justifyContent: 'space-between', // アイコンを均等に配置
-    paddingRight: 5, // 右側の余白を最小限に
-    marginRight: 0, // 右側のマージンを削除
-  },
-  moodIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: 20,
-    resizeMode: 'contain',
-    position: 'absolute', // 各アイコンも絶対配置
-  },
-  absoluteYAxis: {
-    position: 'absolute',
-    top: 0, // グラフの上部余白を考慮
-    left: 20, // 左端からの距離
-    width: 32, // アイコンの幅
-    height: 220, // グラフの高さと同じ
-    zIndex: 1, // グラフの上に表示
   },
   noDataContainer: {
     height: 220,

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -3,23 +3,9 @@ import { StyleSheet, View, Dimensions } from 'react-native';
 import { Image } from 'expo-image'
 import { LineChart } from 'react-native-chart-kit';
 import Header from '../analysis/components/Header';
+import feelingImageList from '../constants/feelingImageList';
 
 const screenWidth = Dimensions.get('window').width;
-
-// 用意した画像をrequireで読み込み、配列にまとめる
-// 上から順（良い気分 -> 悪い気分）に並べるのがポイント
-const moodImages = [
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('../../../assets/images/excellent_icon.png'), // データ値: 0
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('../../../assets/images/good_icon.png'), // データ値: 1
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('../../../assets/images/normal_icon.png'), // データ値: 2
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('../../../assets/images/bad_icon.png'), // データ値: 3
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  require('../../../assets/images/terrible_icon.png'), // データ値: 4
-];
 
 const MoodChartWithIcons = () => {
   // グラフ用のデータ
@@ -94,7 +80,7 @@ const MoodChartWithIcons = () => {
 
           {/* 絶対配置でY軸アイコンを配置 */}
           <View style={styles.absoluteYAxis}>
-            {moodImages.map((imgSrc, index) => (
+            {feelingImageList.map((imgSrc, index) => (
               <Image
                 key={index}
                 source={imgSrc}

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -28,15 +28,7 @@ const MoodChartWithIcons = () => {
       {
         // 画像のグラフをざっくり再現
         // データの値はmoodImagesのインデックスに対応させます (0が一番上、4が一番下)
-        data: [
-          0, // 7/1: 最高
-          1,
-          4, // 7/3あたり: 最悪
-          2,
-          1,
-          4, // 7/8あたり: 最悪
-          0, // 7/11: 最高
-        ],
+        data: [0, 1, 4, 2, 1, 4, 0],
         color: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // 線の色 (黒)
         strokeWidth: 2,
       },
@@ -45,41 +37,23 @@ const MoodChartWithIcons = () => {
 
   // グラフのスタイル設定
   const chartConfig = {
-    backgroundGradientFrom: '#ffffff',
-    backgroundGradientTo: '#ffffff',
-    color: (opacity = 1) => `rgba(200, 200, 200, ${opacity})`, // グリッド線やラベルの色
+    backgroundGradientFrom: '#FFFFFF',
+    backgroundGradientTo: '#FFFFFF',
+    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`, // グリッド線やラベルの色
     labelColor: (opacity = 1) => `rgba(100, 100, 100, ${opacity})`, // X軸ラベルの色
     strokeWidth: 2,
     // データポイントの丸を非表示にする
     propsForDots: {
       r: '3',
       strokeWidth: '0',
+      fill: '#000000',
     },
-    // Y軸の数値を非表示
-    withVerticalLabels: false,
-    // 水平のグリッド線を非表示
-    withHorizontalLines: false,
-    // 垂直のグリッド線は表示
-    withVerticalLines: true,
   };
 
   return (
     <View style={styles.card}>
       {/* グラフエリア */}
       <View style={styles.chartContainer}>
-        {/* カスタムY軸 (アイコン) */}
-        <View style={styles.customYAxis}>
-          {moodImages.map((imgSrc, index) => (
-            <Image
-              key={index}
-              source={imgSrc}
-              style={styles.moodIcon}
-              contentFit="cover"
-              cachePolicy="memory-disk"
-            />
-          ))}
-        </View>
-
         {/* グラフ本体 */}
         <LineChart
           data={data}
@@ -87,17 +61,34 @@ const MoodChartWithIcons = () => {
           height={220}
           chartConfig={chartConfig}
           withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
+          withVerticalLabels={true} // X軸のラベルは表示
           withHorizontalLines={true} // 水平線を表示
           withDots={true} // データポイントを非表示
           // bezierを付けないことで、カクカクした線になる
-          style={styles.chart}
           // データを0から開始しないようにする（データの最小値が基点になる）
           fromZero={false}
-          // Y軸のラベルを描画しないためのオフセット
-          yLabelsOffset={20}
           // 5段階なので4つの区切り
           segments={4}
         />
+
+        {/* 絶対配置でY軸アイコンを配置 */}
+        <View style={styles.absoluteYAxis}>
+          {moodImages.map((imgSrc, index) => (
+            <Image
+              key={index}
+              source={imgSrc}
+              style={[
+                styles.moodIcon,
+                {
+                  top: (index * 41), // 各アイコンの位置を計算（36px間隔）
+                  left: 0, // 左端に配置
+                }
+              ]}
+              contentFit="cover"
+              cachePolicy="memory-disk"
+            />
+          ))}
+        </View>
       </View>
     </View>
   );
@@ -121,21 +112,29 @@ const styles = StyleSheet.create({
   chartContainer: {
     flexDirection: 'row',
     alignItems: 'flex-start', // アイコンとグラフの上端を合わせる
+    justifyContent: 'flex-start', // 左寄せ
+    position: 'relative', // 絶対配置の基準点
   },
   customYAxis: {
     height: 220, // グラフの高さと合わせる
     justifyContent: 'space-between', // アイコンを均等に配置
-    paddingRight: 10,
-    paddingVertical: 5, // 上下の余白を微調整
+    paddingRight: 5, // 右側の余白を最小限に
+    marginRight: 0, // 右側のマージンを削除
   },
   moodIcon: {
     width: 32,
     height: 32,
+    borderRadius: 20,
     resizeMode: 'contain',
+    position: 'absolute', // 各アイコンも絶対配置
   },
-  chart: {
-    // グラフの左側に余白が自動で入る場合があるので、マイナスマージンで調整
-    marginLeft: -15,
+  absoluteYAxis: {
+    position: 'absolute',
+    top: 0, // グラフの上部余白を考慮
+    left: 10, // 左端からの距離
+    width: 32, // アイコンの幅
+    height: 220, // グラフの高さと同じ
+    zIndex: 1, // グラフの上に表示
   },
 });
 

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -120,12 +120,6 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     paddingVertical: 20,
     paddingHorizontal: 10,
-    // 影をつけたい場合
-    // shadowColor: '#000',
-    // shadowOffset: { width: 0, height: 2 },
-    // shadowOpacity: 0.1,
-    // shadowRadius: 4,
-    // elevation: 3,
   },
   chartContainer: {
     flexDirection: 'row',

--- a/src/app/(tabs)/analysis.tsx
+++ b/src/app/(tabs)/analysis.tsx
@@ -151,7 +151,7 @@ export default function analysis() {
               segments={4}
               // X軸の一番下の線を表示するための設定
               withInnerLines={false} // 内側の線を表示
-              hidePointsAtIndex={[0, chartDataValues.length + 1]}
+              hidePointsAtIndex={[chartDataValues.length + 1]}
               getDotProps={(value) => {
                 if (value === null) {
                   return { r: '0' }; // 半径0で見えなくする

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -93,6 +93,7 @@ export default function home() {
   return (
     <View style={styles.container}>
       <Header
+        title="日記一覧"
         userInfo={userInfo}
         selectedUserInfo={selectedUserInfo}
         friendsData={friendsData}

--- a/src/app/actions/backend/fetchFriendAccountId.tsx
+++ b/src/app/actions/backend/fetchFriendAccountId.tsx
@@ -2,7 +2,6 @@ import { collection, query, getDocs } from 'firebase/firestore';
 import { db } from '../../../config';
 
 export default async function fetchFriendAccountId(userId?: string): Promise<string[]> {
-  console.log("userId", userId)
   try {
     const friendsRef = collection(db, `users/${userId}/friends`);
     const friendsQuery = query(friendsRef);

--- a/src/app/actions/backend/fetchFriends.tsx
+++ b/src/app/actions/backend/fetchFriends.tsx
@@ -1,0 +1,13 @@
+import { FriendInfoType } from '../../../../type/friend';
+import fetchFriendList from '../../myPage/action/backend/fetchFriendList';
+
+export default async function fetchFriends(setFriendsData: (data: FriendInfoType[]) => void, userId?: string) {
+  try {
+    const data = await fetchFriendList(userId);
+    setFriendsData(data);
+    console.log('友人情報の取得に成功しました');
+  } catch (error) {
+    console.error('友人情報の取得に失敗しました:', error);
+    setFriendsData([]);
+  }
+}

--- a/src/app/analysis/actions/backend/fetchFeelingScore.ts
+++ b/src/app/analysis/actions/backend/fetchFeelingScore.ts
@@ -1,0 +1,30 @@
+import { db } from '../../../../config';
+import { collection, onSnapshot, query, orderBy, where } from 'firebase/firestore';
+import dayjs from 'dayjs';
+
+export default function fetchFeelingScore(
+  setFeelingScoreList: (feelingScoreList: number[]) => void,
+  setFeelingDateList: (feelingDateList: string[]) => void,
+  startOfMonth: dayjs.Dayjs,
+  endOfMonth: dayjs.Dayjs,
+  userId?: string,
+) {
+  const ref = collection(db, `users/${userId}/feelingScores`)
+  const q = query(ref, orderBy('diaryDate', 'asc'), where('diaryDate', '>=', startOfMonth.toDate()), where('diaryDate', '<', endOfMonth.toDate()))
+  const unsubscribe = onSnapshot(q, (snapshot) => {
+    const remoteFeelingScoreList: number[] = []
+    const remoteFeelingDateList: string[] = []
+    snapshot.docs.forEach((doc) => {
+      const { feelingScore, diaryDate } = doc.data();
+      remoteFeelingScoreList.push(feelingScore)
+      // 1. TimestampオブジェクトをJavaScriptのDateオブジェクトに変換
+      const jsDate = diaryDate.toDate();
+      // 2. dayjsを使って 'M/D' (月/日) 形式の文字列にフォーマット
+      const formattedDate = dayjs(jsDate).format('M/D');
+      remoteFeelingDateList.push(formattedDate)
+    })
+    setFeelingScoreList(remoteFeelingScoreList)
+    setFeelingDateList(remoteFeelingDateList)
+  })
+  return unsubscribe;
+}

--- a/src/app/analysis/actions/backend/fetchFeelingScore.ts
+++ b/src/app/analysis/actions/backend/fetchFeelingScore.ts
@@ -4,22 +4,29 @@ import dayjs from 'dayjs';
 import { FeelingScoreType } from '../../../../../type/feelingScore';
 
 export default function fetchFeelingScore(
+  userId: string,
   setFeelingScoreDates: (feelingScoreDates: FeelingScoreType[]) => void,
   startOfMonth: dayjs.Dayjs,
   endOfMonth: dayjs.Dayjs,
-  userId?: string,
 ) {
-  const ref = collection(db, `users/${userId}/feelingScores`)
-  const q = query(ref, orderBy('diaryDate', 'asc'), where('diaryDate', '>=', startOfMonth.toDate()), where('diaryDate', '<', endOfMonth.toDate()))
-  const unsubscribe = onSnapshot(q, (snapshot) => {
-    const remoteChartData: FeelingScoreType[] = []
-    snapshot.docs.forEach((doc) => {
-      const { diaryDate, feelingScore } = doc.data() as { diaryDate: Timestamp, feelingScore: number};
-      // Timestampオブジェクトを 'M/D' 形式の文字列に変換
-      const formattedDate = dayjs(diaryDate.toDate()).format('M/D');
-      remoteChartData.push({ date: formattedDate, value: feelingScore });
+  if (!userId) return;
+  try {
+    const ref = collection(db, `users/${userId}/feelingScores`)
+    const q = query(ref, orderBy('diaryDate', 'asc'), where('diaryDate', '>=', startOfMonth.toDate()), where('diaryDate', '<', endOfMonth.toDate()))
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const remoteChartData: FeelingScoreType[] = []
+      snapshot.docs.forEach((doc) => {
+        const { diaryDate, feelingScore } = doc.data() as { diaryDate: Timestamp, feelingScore: number};
+        // Timestampオブジェクトを 'M/D' 形式の文字列に変換
+        const formattedDate = dayjs(diaryDate.toDate()).format('M/D');
+        remoteChartData.push({ date: formattedDate, value: feelingScore });
+      })
+      setFeelingScoreDates(remoteChartData)
     })
-    setFeelingScoreDates(remoteChartData)
-  })
-  return unsubscribe;
+    console.log('感情スコアの取得に成功しました');
+    return unsubscribe;
+  } catch (error) {
+    console.error('感情スコアの取得に失敗しました:', error);
+    setFeelingScoreDates([]);
+  }
 }

--- a/src/app/analysis/components/FeelingScoreGraph.tsx
+++ b/src/app/analysis/components/FeelingScoreGraph.tsx
@@ -1,0 +1,152 @@
+import React, { useMemo } from 'react'
+import { View, StyleSheet, Dimensions } from 'react-native'
+import { LineChart } from 'react-native-chart-kit'
+import feelingImageList from '../../constants/feelingImageList'
+import { Image } from 'expo-image'
+
+type Props = {
+  allDaysInMonth: string[]
+  chartDataValues: (number | null)[]
+}
+
+export default function FeelingScoreGraph({ allDaysInMonth, chartDataValues }: Props) {
+  const screenWidth = Dimensions.get('window').width;
+  const data = useMemo(() => {
+    const yAxisMax = 10;
+    const yAxisMin = -10;
+    return {
+      // ダミーデータに合わせて、labelsの最後に空文字を追加
+      labels: [ ...allDaysInMonth, '', ''],
+      datasets: [
+        {
+          data: chartDataValues,
+          color: (opacity = 1) => `rgba(255, 165, 0, ${opacity})`,
+          strokeWidth: 3,
+        },
+        {
+          // ダミーデータ: Y軸のスケールを固定するための非表示データ
+          data: [yAxisMax, yAxisMin],
+          // 線とドットを完全に見えなくする
+          withDots: false,
+          color: () => `rgba(0, 0, 0, 0)`,
+          strokeWidth: 0,
+        },
+      ],
+    };
+  }, [chartDataValues, allDaysInMonth]);
+
+  const chartConfig = {
+    backgroundGradientFrom: '#FFFFFF',
+    backgroundGradientTo: '#FFFFFF',
+    color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`, // グリッド線の色（黒）
+    labelColor: (opacity = 1) => `rgba(0, 0, 0, ${opacity})`, // X軸ラベルの色
+    strokeWidth: 2,
+    propsForDots: {
+      r: '4',
+      strokeWidth: '0',
+      fill: '#FFA500',
+    },
+    // グリッド線の設定
+    propsForBackgroundLines: {
+      strokeDasharray: '', // 実線
+      strokeWidth: 1, // 線の太さ
+      stroke: '#000000', // 線の色
+    },
+    // Y軸の線を表示
+    propsForVerticalLabels: {
+      fontSize: 0, // Y軸ラベルは非表示
+    },
+    // X軸の線を表示
+    propsForHorizontalLabels: {
+      fontSize: 12, // X軸ラベルのフォントサイズ
+
+    },
+  };
+
+  return (
+    <View style={styles.chartContainer}>
+      {/* グラフ本体 */}
+      <LineChart
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data={data as any}
+        width={screenWidth - 80} // カードのpaddingやY軸の幅を引く
+        height={220}
+        chartConfig={chartConfig}
+        withHorizontalLabels={false} // Y軸のラベルを描画しないためのオフセット
+        withVerticalLabels={true} // X軸のラベルは表示
+        withHorizontalLines={true} // 水平線を表示
+        withVerticalLines={true} // 垂直線を表示
+        withDots={true} // データポイントを非表示
+        // bezierを付けないことで、カクカクした線になる
+        // データを0から開始しないようにする（データの最小値が基点になる）
+        fromZero={false}
+        // 5段階なので4つの区切り
+        segments={4}
+        // X軸の一番下の線を表示するための設定
+        withInnerLines={false} // 内側の線を表示
+        hidePointsAtIndex={[chartDataValues.length + 1]}
+        getDotProps={(value) => {
+          if (value === null) {
+            return { r: '0' }; // 半径0で見えなくする
+          }
+          return chartConfig.propsForDots;
+        }}
+        formatXLabel={(label) => {
+          const day = parseInt(label.split('/')[1], 10);
+          // 1日、または5の倍数の日だけラベルを表示
+          // ダミーデータ用の空ラベルは表示しない
+          if (label === '') {
+            return '';
+          }
+          if (day === 1 || day % 5 === 0) {
+            return label;
+          }
+          return ''; // それ以外は空文字にして非表示
+        }}
+      />
+      {/* 絶対配置でY軸アイコンを配置 */}
+      <View style={styles.absoluteYAxis}>
+        {feelingImageList.map((imgSrc, index) => (
+          <Image
+            key={index}
+            source={imgSrc}
+            style={[
+              styles.moodIcon,
+              {
+                top: (index * 41), // 各アイコンの位置を計算（36px間隔）
+                left: 0,
+              }
+            ]}
+            contentFit="cover"
+            cachePolicy="memory-disk"
+          />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+// スタイル定義
+const styles = StyleSheet.create({
+  chartContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start', // アイコンとグラフの上端を合わせる
+    justifyContent: 'flex-start', // 左寄せ
+    position: 'relative', // 絶対配置の基準点
+  },
+  moodIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 20,
+    resizeMode: 'contain',
+    position: 'absolute', // 各アイコンも絶対配置
+  },
+  absoluteYAxis: {
+    position: 'absolute',
+    top: 0,
+    left: 20,
+    width: 32, // アイコンの幅
+    height: 220, // グラフの高さと同じ
+    zIndex: 1, // グラフの上に表示
+  },
+});

--- a/src/app/analysis/components/FeelingScoreGraph.tsx
+++ b/src/app/analysis/components/FeelingScoreGraph.tsx
@@ -93,11 +93,11 @@ export default function FeelingScoreGraph({ allDaysInMonth, chartDataValues }: P
         }}
         formatXLabel={(label) => {
           const day = parseInt(label.split('/')[1], 10);
-          // 1日、または5の倍数の日だけラベルを表示
           // ダミーデータ用の空ラベルは表示しない
           if (label === '') {
             return '';
           }
+          // 1日、または5の倍数の日だけラベルを表示
           if (day === 1 || day % 5 === 0) {
             return label;
           }
@@ -113,7 +113,7 @@ export default function FeelingScoreGraph({ allDaysInMonth, chartDataValues }: P
             style={[
               styles.moodIcon,
               {
-                top: (index * 41), // 各アイコンの位置を計算（36px間隔）
+                top: (index * 41), // 各アイコンの位置を計算（41px間隔）
                 left: 0,
               }
             ]}

--- a/src/app/analysis/components/Header.tsx
+++ b/src/app/analysis/components/Header.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Header() {
+  return (
+    <>
+      <View style={styles.header}>
+        {/* ヘッダー左側 */}
+        <View style={styles.headerLeft}>
+          {/* 左側のスペーサー */}
+        </View>
+        {/* 日付タイトル */}
+        <View style={styles.headerCenter}>
+          <Text style={styles.headerTitle}>分析レポート</Text>
+        </View>
+        {/* ヘッダー右側 */}
+        <View style={styles.headerRight}>
+          {/* 右側のスペーサー */}
+        </View>
+      </View>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    height: 60,
+    backgroundColor: '#ffffff',
+  },
+  headerLeft: {
+    width: 60
+  },
+  headerCenter: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: 16,
+    lineHeight: 30,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginHorizontal: 8,
+  },
+  headerRight: {
+    width: 60
+  },
+});

--- a/src/app/components/Icon/AnalysisIcon.tsx
+++ b/src/app/components/Icon/AnalysisIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface AnalysisIconProps {
+  width?: number;
+  height?: number;
+  color?: string;
+}
+
+export default function AnalysisIcon({ width = 32, height = 32, color = 'black' }: AnalysisIconProps) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 32 32" fill="none">
+      <Path
+        d="M4.66666 5.33325V23.3333C4.66666 24.3941 5.08809 25.4115 5.83824 26.1617C6.58838 26.9118 7.6058 27.3333 8.66666 27.3333H26.6667"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M8.66666 19.9999L14.6667 13.9999L19.3333 18.6666L26.6667 11.3333"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}

--- a/src/app/constants/feelingImageList.ts
+++ b/src/app/constants/feelingImageList.ts
@@ -1,0 +1,13 @@
+export const feelingImageList = [
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/excellent_icon.png'), // データ値: 0
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/good_icon.png'), // データ値: 1
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/normal_icon.png'), // データ値: 2
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/bad_icon.png'), // データ値: 3
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('../../../assets/images/terrible_icon.png'), // データ値: 4
+];
+export default feelingImageList;

--- a/src/app/constants/feelings.ts
+++ b/src/app/constants/feelings.ts
@@ -1,13 +1,13 @@
 export const feelings = [
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  { name: '絶好調', image: require('../../../assets/images/excellent_icon.png') },
+  { name: '絶好調', image: require('../../../assets/images/excellent_icon.png'), score: 10 },
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  { name: '好調', image: require('../../../assets/images/good_icon.png') },
+  { name: '好調', image: require('../../../assets/images/good_icon.png'), score: 5 },
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  { name: '普通', image: require('../../../assets/images/normal_icon.png') },
+  { name: '普通', image: require('../../../assets/images/normal_icon.png'), score: 0 },
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  { name: '不調', image: require('../../../assets/images/bad_icon.png') },
+  { name: '不調', image: require('../../../assets/images/bad_icon.png'), score: -5 },
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  { name: '絶不調', image: require('../../../assets/images/terrible_icon.png') },
+  { name: '絶不調', image: require('../../../assets/images/terrible_icon.png'), score: -10 },
 ];
 export default feelings;

--- a/src/app/diary/creation/action/backend/createDiary.ts
+++ b/src/app/diary/creation/action/backend/createDiary.ts
@@ -5,6 +5,7 @@ import { collection, Timestamp, addDoc } from 'firebase/firestore';
 import formatDate from '../../../../actions/formatData';
 import { useRouter } from 'expo-router';
 import checkExistingDiary from '../checkExistingDiary';
+import feelings from '../../../../constants/feelings';
 
 export default async function createDiary(
   selectedFeeling: string | null,
@@ -35,8 +36,16 @@ export default async function createDiary(
   }
 
   try {
-    const ref = collection(db, `users/${userId}/diaries`);
-    await addDoc(ref, {
+    // 体調のスコアを取得
+    const feelingScore = feelings.find((feeling) => feeling.name === selectedFeeling)?.score;
+    const feelingScoresRef = collection(db, `users/${userId}/feelingScores`);
+    await addDoc(feelingScoresRef, {
+      feelingScore: feelingScore,
+      diaryDate: Timestamp.fromDate(date.toDate()),
+      updatedAt: Timestamp.fromDate(new Date()),
+    });
+    const diariesRef = collection(db, `users/${userId}/diaries`);
+    await addDoc(diariesRef, {
       diaryText,
       diaryDate: Timestamp.fromDate(date.toDate()),
       feeling: selectedFeeling,

--- a/src/app/diary/list/actions/backend/fetchDiaries.ts
+++ b/src/app/diary/list/actions/backend/fetchDiaries.ts
@@ -4,10 +4,10 @@ import { DiaryType } from '../../../../../../type/diary';
 import dayjs from 'dayjs';
 
 export default function fetchDiaries(
+  userId: string,
   setDiaryLists: (diaryLists: DiaryType[]) => void,
   startOfMonth: dayjs.Dayjs,
   endOfMonth: dayjs.Dayjs,
-  userId?: string,
 ) {
   const ref = collection(db, `users/${userId}/diaries`)
   const q = query(ref, orderBy('diaryDate', 'desc'), where('diaryDate', '>=', startOfMonth.toDate()), where('diaryDate', '<', endOfMonth.toDate()))

--- a/src/app/diary/list/actions/backend/fetchDiaries.ts
+++ b/src/app/diary/list/actions/backend/fetchDiaries.ts
@@ -4,10 +4,10 @@ import { DiaryType } from '../../../../../../type/diary';
 import dayjs from 'dayjs';
 
 export default function fetchDiaries(
-  userId: string,
   setDiaryLists: (diaryLists: DiaryType[]) => void,
   startOfMonth: dayjs.Dayjs,
-  endOfMonth: dayjs.Dayjs
+  endOfMonth: dayjs.Dayjs,
+  userId?: string,
 ) {
   const ref = collection(db, `users/${userId}/diaries`)
   const q = query(ref, orderBy('diaryDate', 'desc'), where('diaryDate', '>=', startOfMonth.toDate()), where('diaryDate', '<', endOfMonth.toDate()))

--- a/src/app/diary/list/components/Header.tsx
+++ b/src/app/diary/list/components/Header.tsx
@@ -6,13 +6,14 @@ import { UserInfoType } from '../../../../../type/userInfo';
 import UserSelectionModal from './UserSelectionModal';
 
 type Props = {
+  title: string
   userInfo: UserInfoType | null
   selectedUserInfo: UserInfoType | null
   friendsData: FriendInfoType[]
   setSelectedUserId: (selectedUserId: string) => void
 }
 
-export default function Header({ userInfo, selectedUserInfo, friendsData, setSelectedUserId }: Props) {
+export default function Header({ title, userInfo, selectedUserInfo, friendsData, setSelectedUserId }: Props) {
   // ユーザー選択モーダルの表示状態を管理
   const [isUserSelectionModalVisible, setIsUserSelectionModalVisible] = useState(false);
 
@@ -40,7 +41,7 @@ export default function Header({ userInfo, selectedUserInfo, friendsData, setSel
         </View>
         {/* 日付タイトル */}
         <View style={styles.headerCenter}>
-          <Text style={styles.headerTitle}>日記一覧</Text>
+          <Text style={styles.headerTitle}>{title}</Text>
         </View>
         {/* ヘッダー右側 */}
         <View style={styles.headerRight}>

--- a/src/app/diary/show/actions/backend/deleteDiary.ts
+++ b/src/app/diary/show/actions/backend/deleteDiary.ts
@@ -20,7 +20,9 @@ export default async function deleteDiary(userId?: string, diaryId?: string) {
           onPress: async () => {
             try {
               const diaryRef = doc(db, `users/${userId}/diaries/${diaryId}`);
+              const feelingScoreRef = doc(db, `users/${userId}/feelingScores/${diaryId}`);
               await deleteDoc(diaryRef);
+              await deleteDoc(feelingScoreRef);
               console.log('日記を削除しました');
               handleBack();
             } catch (error) {

--- a/type/feelingScore.tsx
+++ b/type/feelingScore.tsx
@@ -1,7 +1,0 @@
-import dayjs from 'dayjs';
-
-export type FeelingScoreType = {
-  feelingScore: number;
-  diaryDate: dayjs.Dayjs;
-  updatedAt: dayjs.Dayjs;
-}

--- a/type/feelingScore.tsx
+++ b/type/feelingScore.tsx
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+
+export type FeelingScoreType = {
+  feelingScore: number;
+  diaryDate: dayjs.Dayjs;
+  updatedAt: dayjs.Dayjs;
+}

--- a/type/feelingScore.tsx
+++ b/type/feelingScore.tsx
@@ -1,0 +1,4 @@
+export type FeelingScoreType = {
+  date: string;
+  value: number;
+}


### PR DESCRIPTION
- [x] 分析のタグを追加
- [x] 分析のアイコンを用意
- [x] 分析結果を表示
  - [x] feelingScoresコレクションから全てのデータを取得
  - [x] 取得したデータを分析表示する
  - [x] データが1つもない時は「データがありません」を表示する。
  - [x] ユーザーIDを変更たびにfeelingScoresコレクションを取り直す
- [x] ヘッダーを作成
  - [x] ヘッダータイトルは「分析レポート」
  - [x] 左側にはユーザーを切り替え
- [x] 日記削除処理と同時に感情スコアも削除 